### PR TITLE
fix Jest error

### DIFF
--- a/src/.internal/core/Sprite.ts
+++ b/src/.internal/core/Sprite.ts
@@ -7288,7 +7288,7 @@ export class Sprite extends BaseObjectEvents implements IAnimatable {
 	protected setPath(value: string): boolean {
 		if (this.setPropertyValue("path", value)) {
 
-			if (!this.element || !(this.element instanceof SVGPathElement)) {
+			if (!this.element) {
 				this.element = this.paper.add("path");
 			}
 			this.element.attr({ "d": value });


### PR DESCRIPTION
An error occurred while testing via Jest "TypeError: Function has non-object prototype 'undefined' in instanceof check".
Because of this error, the test results were incorrect.