### PR TITLE
[pt_BR.ts] fix wrong translation

### DIFF
--- a/src/lang/pt_BR.ts
+++ b/src/lang/pt_BR.ts
@@ -132,7 +132,7 @@ export default {
 
 	// Various chart controls.
 	// Shown as a tooltip on zoom out button.
-	"Zoom Out": "Aumentar Zoom",
+	"Zoom Out": "Diminuir o zoom",
 
 	// Timeline buttons
 	"Play": "Play",


### PR DESCRIPTION
change  "aumentar" to "diminuir".
"Aumentar o zoom" means "Zoom In" while "Diminuir o zoom" means "Zoom Out"