### PR TITLE
Allow skipping on certain period-changes

### DIFF
--- a/src/.internal/charts/axes/DateAxis.ts
+++ b/src/.internal/charts/axes/DateAxis.ts
@@ -403,6 +403,26 @@ export class DateAxis<T extends AxisRenderer = AxisRenderer> extends ValueAxis<T
 	public periodChangeDateFormats: Dictionary<TimeUnit, string | Intl.DateTimeFormatOptions> = new Dictionary<TimeUnit, string | Intl.DateTimeFormatOptions>();
 
 	/**
+	 * When detecting a period change, these units will be skipped in favor of a larger unit.
+	 *
+	 * This allows us to format the next higher unit while zooming, like zooming into:
+	 *
+	 * `22:00 - 23:00 - [b]Jan 1[b] - 01:00 - ...`
+	 *
+	 * Instead of:
+	 *
+	 * `23:00 - 23:30 - [b]00:00[b] - 00:30`
+	 *
+	 * We can have:
+	 *
+	 * `23:00 - 23:30 - [b]Jan 1[b] - 00:30`
+	 *
+	 * This gets overriden by setting `markUnitChange = false`.
+	 */
+
+	public skipPeriodChanges: List<TimeUnit> = new List<TimeUnit>();
+
+	/**
 	 * At which intervals grid elements are displayed.
 	 */
 	protected _gridInterval: ITimeInterval;
@@ -1260,6 +1280,16 @@ export class DateAxis<T extends AxisRenderer = AxisRenderer> extends ValueAxis<T
 			let timeUnit = this._gridInterval.timeUnit;
 			let intervalCount = this._gridInterval.count;
 			let prevGridDate = $time.copy(this._gridDate);
+			let timeUnitAfterSkipping = timeUnit;
+			if (this.markUnitChange) {
+				while (this.skipPeriodChanges.contains(timeUnitAfterSkipping)) {
+					timeUnitAfterSkipping = $time.getNextUnit(timeUnitAfterSkipping);
+				}
+				if (timeUnitAfterSkipping === "year") {
+					timeUnitAfterSkipping = null;
+				}
+			}
+			let nextGridUnit = $time.getNextUnit(timeUnitAfterSkipping);
 
 			let dataItemsIterator = this._dataItemsIterator;
 			this.resetIterators();
@@ -1274,9 +1304,9 @@ export class DateAxis<T extends AxisRenderer = AxisRenderer> extends ValueAxis<T
 				let format = this.dateFormats.getKey(timeUnit);
 
 				if (this.markUnitChange && prevGridDate) {
-					if ($time.checkChange(date, prevGridDate, this._nextGridUnit, this._df.utc)) {
-						if (timeUnit !== "year") {
-							format = this.periodChangeDateFormats.getKey(timeUnit);
+					if ($time.checkChange(date, prevGridDate, nextGridUnit, this._df.utc)) {
+						if (timeUnitAfterSkipping) {
+							format = this.periodChangeDateFormats.getKey(timeUnitAfterSkipping);
 						}
 					}
 				}
@@ -1308,6 +1338,16 @@ export class DateAxis<T extends AxisRenderer = AxisRenderer> extends ValueAxis<T
 					if (axisBreak.breakSize > 0) {
 						let timeUnit: TimeUnit = axisBreak.gridInterval.timeUnit;
 						let intervalCount: number = axisBreak.gridInterval.count;
+						let timeUnitAfterSkipping: TimeUnit = timeUnit;
+						if (this.markUnitChange) {
+							while (this.skipPeriodChanges.contains(timeUnitAfterSkipping)) {
+								timeUnitAfterSkipping = $time.getNextUnit(timeUnitAfterSkipping);
+							}
+							if (timeUnitAfterSkipping === "year") {
+								timeUnitAfterSkipping = null;
+							}
+						}
+						let nextGridUnit: TimeUnit = $time.getNextUnit(timeUnitAfterSkipping);
 
 						// only add grid if gap is bigger then minGridDistance
 						if ($math.getDistance(axisBreak.startPoint, axisBreak.endPoint) > renderer.minGridDistance * 4) {
@@ -1326,9 +1366,9 @@ export class DateAxis<T extends AxisRenderer = AxisRenderer> extends ValueAxis<T
 									let format = this.dateFormats.getKey(timeUnit);
 
 									if (this.markUnitChange && prevGridDate) {
-										if ($time.checkChange(date, prevGridDate, this._nextGridUnit, this._df.utc)) {
-											if (timeUnit !== "year") {
-												format = this.periodChangeDateFormats.getKey(timeUnit);
+										if ($time.checkChange(date, prevGridDate, nextGridUnit, this._df.utc)) {
+											if (timeUnitAfterSkipping) {
+												format = this.periodChangeDateFormats.getKey(timeUnitAfterSkipping);
 											}
 										}
 									}


### PR DESCRIPTION
This PR introduces a new property named `skipPeriodChanges` to `DateAxis`; a `List` that accepts elements of type `TimeUnit`. When detecting a period-change, these units will be skipped in favor of a larger unit.

Say we have data with `date` values as granular as a "second" and we are interested in having period changes formatted on "hour" so we show date changes in a different format. Using `dateAxis.periodChangeDateFormats.setKey("hour", "[bold]MMM d");` would produce an x-axis with:
`... - 22:00 - 23:00 -`**`Jan 20`**`- 01:00 - 02:00 - ...`
Zooming in on the data enough to get the graph to show minutes would produce an x-axis with:
`... - 23:00 - 23:30 - 00:00 - 00:30 - 01:00 - ...`

Setting `dateAxis.periodChangeDateFormats.setKey("minute", "[bold]MMM d");` would make the x-axis be: `... -`**`Jan 19`**`- 23:30 -`**`Jan 20`**`- 00:30 -`**`Jan 20`**`- ...` which doesn't appear desirable.

However, with this change, setting `dateAxis.skipPeriodChanges.setAll(['minute', 'second']);` the x-axis would look like: `... - 23:00 - 23:30 -`**`Jan 20`**`- 00:30 - 01:00 - ...`.

The way this works is that if a certain unit it asked to be skipped, it simply looks for the next available time-unit for detection and formatting.
