### PR TITLE
fix: ignore shims in production

### DIFF
--- a/dist/ember/index.js
+++ b/dist/ember/index.js
@@ -20,6 +20,8 @@ module.exports = {
       app.import('vendor/script/amcharts4/' + name + '.js');
     });
 
-    app.import('vendor/shims/amcharts4.js');
+    if (app.env !== 'production') {
+      app.import('vendor/shims/amcharts4.js');
+    }
   }
 };


### PR DESCRIPTION
I don't think a 50kB shim files will be usefull in production ?