### PR TITLE
Avoid quadratic behavior when validating sprites

### DIFF
--- a/src/.internal/core/Registry.ts
+++ b/src/.internal/core/Registry.ts
@@ -103,12 +103,21 @@ export class Registry {
 	protected _placeholders: { [index: string]: string } = {};
 
 	/**
-	 * A list of invalid(ated) [[Sprite]] objects that need to be re-validated
+	 * Lists of invalid(ated) [[Sprite]] objects that need to be re-validated
 	 * during next cycle.
 	 *
 	 * @ignore Exclude from docs
 	 */
 	public invalidSprites: { [index: string]: Array<Sprite> } = {};
+
+        /**
+         * Objects with the keys given by the uids of no longer
+         * invalid [[Sprite]] objects that should be removed from the
+         * invalid Sprites.
+         *
+         * @ignore Exclude from docs
+         */
+        public validatedSpritesBatchPurge: { [index: string]: any } = {};
 
 	/**
 	 * Components are added to this list when their data provider changes to
@@ -194,6 +203,7 @@ export class Registry {
 		this.uid = this.getUniqueId();
 
 		this.invalidSprites.noBase = [];
+		this.validatedSpritesBatchPurge.noBase = {};
 		this.invalidDatas.noBase = [];
 		this.invalidLayouts.noBase = [];
 		this.invalidPositions.noBase = [];
@@ -375,10 +385,16 @@ export class Registry {
 	 */
 	public removeFromInvalidSprites(sprite: Sprite) {
 		if (sprite.baseId) {
-			$array.remove(this.invalidSprites[sprite.baseId], sprite);
+			if (!this.validatedSpritesBatchPurge[spriteBaseId][sprite.uid]) {
+				// not doing batch purge, so remove sprite from invalid sprites right here
+				$array.remove(this.invalidSprites[sprite.baseId], sprite);
+			}
 		}
 
-		$array.remove(this.invalidSprites["noBase"], sprite);
+		if (!this.validatedSpritesBatchPurge[spriteBaseId][sprite.uid]) {
+			// not doing batch purge, so remove sprite from invalid sprites right here
+			$array.remove(this.invalidSprites["noBase"], sprite);
+		}
 	}
 
 

--- a/src/.internal/core/System.ts
+++ b/src/.internal/core/System.ts
@@ -273,8 +273,8 @@ export class System {
 
 		$object.each(registry.invalidSprites, (key, invalidSprites) => {
 			let count = 0;
-
-			while (invalidSprites.length > 0) {
+			const toPurge = registry.validatedSpritesBatchPurge[key];
+			for (const index = invalidSprites.length - 1; index >= 0; index--) {
 				this.validateLayouts(key);
 				this.validatePositions(key);
 
@@ -287,9 +287,12 @@ export class System {
 					count = 0;
 				}
 
-				let sprite: Sprite = invalidSprites[invalidSprites.length - 1];
+				let sprite: Sprite = invalidSprites[index];
 
 				// we need to check this, as validateLayout might validate sprite
+				if (sprite) {
+					toPurge[sprite.uid] = true;
+				}
 				if (sprite && !sprite.isDisposed()) {
 					if (!sprite._systemCheckIfValidate()) {
 						// void

--- a/src/.internal/core/utils/Instance.ts
+++ b/src/.internal/core/utils/Instance.ts
@@ -95,6 +95,7 @@ function createChild<T extends Sprite>(htmlElement: $type.Optional<HTMLElement |
 		let uid = sprite.uid;
 
 		registry.invalidSprites[uid] = [];
+		registry.validatedSpritesBatchPurge[uid] = {};
 		registry.invalidDatas[uid] = [];
 		registry.invalidPositions[uid] = [];
 		registry.invalidLayouts[uid] = [];


### PR DESCRIPTION
This patch resolves quadratic behavior (that caused waiting for several minutes) when loading charts with dates on the x-axis where thousands of datapoints lie on the same date-position.

To this end it avoids removing sprites from a list inside a while loop over that same list.