### PR TITLE
Label: use style instead of invalid attribute

### DIFF
--- a/src/.internal/core/elements/Label.ts
+++ b/src/.internal/core/elements/Label.ts
@@ -1216,7 +1216,7 @@ export class Label extends Container {
 
 		// Don't let labels blled out of the alotted area
 		if (this.truncate || this.wrap) {
-			element.attr({ "overflow": "hidden" });
+			element.addStyle({ "overflow": "hidden" });
 		}
 
 		// Add RTL?


### PR DESCRIPTION
The svg [text](https://svgwg.org/svg2-draft/text.html#TextElement) element does not support an `overflow` attribute. Use the CSS overflow property instead.

This is purely for spec compliance (eg. for accessibility, [WCAG 2.1 SC 4.1.1](https://www.w3.org/TR/WCAG21/#parsing) requires this). It has no effect on behavior, as the `overflow` attribute was treated by most browsers as a CSS property anyways.
This might also increase compatibility with some browsers/SVG parsers that did not support this fallback.

Note that `yarn run build` failed with some unrelated errors on my machine, so I did not include any build files.