### PR TITLE
Label: prevent issues with text wrapping

### DIFF
--- a/src/.internal/core/elements/Label.ts
+++ b/src/.internal/core/elements/Label.ts
@@ -848,6 +848,7 @@ export class Label extends Container {
 
 											// Don't split mid-word
 											splitLines = $utils.splitTextByCharCount(chunk.text, maxChars, true, this.rtl, false);
+											splitLines = splitLines.length ? splitLines : [chunk.text];
 
 											// Check if the first word is too long
 											if ((splitLines[0].length > maxChars) || maxChars === 1) {


### PR DESCRIPTION
This should fix this issue https://github.com/amcharts/amcharts4/issues/3700 but maybe `splitTextByCharCount` should be updated instead?