### PR TITLE
Added type module to package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "@amcharts/amcharts4",
   "version": "4.10.25",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/amcharts/amcharts4.git"


### PR DESCRIPTION
To declare to node environments that this is an ESM module.

Without this, importing in node (via ts-node for example) is problematic.