### PR TITLE
Update DateAxis.ts

### DIFF
--- a/src/.internal/charts/axes/DateAxis.ts
+++ b/src/.internal/charts/axes/DateAxis.ts
@@ -920,7 +920,7 @@ export class DateAxis<T extends AxisRenderer = AxisRenderer> extends ValueAxis<T
 
 			let previousDate = (<any>previousDataItem)[key];
 
-			if (!previousDate || previousDate.getTime() < time) {
+			if (!previousDate || previousDate.getTime() <= time) {
 				return dataItem;
 			}
 			else {


### PR DESCRIPTION
Calculate zoom is failing with maximum call stack exceeded exception, while trying to get lower date dataItem value  and getting into loop with no possible match and throwing max call stack exceeded exception.